### PR TITLE
Fix event type

### DIFF
--- a/src/vscode/Event.hx
+++ b/src/vscode/Event.hx
@@ -14,4 +14,4 @@ package vscode;
  * @example
  * item.onDidChange(function(event) { console.log("Event happened: " + event); });
  */
-typedef Event<T> = (listener:(e:T) -> Void, ?thisArgs:Any, ?disposables:Array<Disposable>) -> Disposable;
+typedef Event<T> = (listener:(e:T) -> Void, ?thisArgs:Any, ?disposables:Array<{dispose:() -> Void}>) -> Disposable;


### PR DESCRIPTION
This PR fixes a compile error in the following code:

```haxe
function activate(context:ExtensionContext) {
    final panel = Vscode.window.createWebviewPanel(
        "foo.bar",
        "Foo Bar",
        Vscode.ViewColumn.One,
        {}
    );
    panel.onDidDispose(
        _ -> {},
        null,
        context.subscriptions  // <- error
    );
}
```
