### PR TITLE
Fix Event<T> argument

### DIFF
--- a/src/vscode/Event.hx
+++ b/src/vscode/Event.hx
@@ -14,4 +14,4 @@ package vscode;
  * @example
  * item.onDidChange(function(event) { console.log("Event happened: " + event); });
  */
-typedef Event<T> = (listener:(e:T) -> Void, ?thisArgs:Any, ?disposables:Array<Disposable>) -> Disposable;
+typedef Event<T> = (listener:(e:T) -> Void, ?thisArgs:Any, ?disposables:Array<{function dispose():Void;}>) -> Disposable;


### PR DESCRIPTION
This PR fixes a compile error in the following code:

```haxe
import vscode.ExtensionContext;
import vscode.ViewColumn;

function activate(context:ExtensionContext) {
	final panel = Vscode.window.createWebviewPanel("viewtype", "title", ViewColumn.Active);
	panel.onDidDispose(
            _ -> {},
            null,
            context.subscriptions // <- type error
	);
}
```